### PR TITLE
Made changes to Winsorized sigma clipping

### DIFF
--- a/SpectralAveraging/Averaging/OutlierRejection.cs
+++ b/SpectralAveraging/Averaging/OutlierRejection.cs
@@ -119,11 +119,11 @@ namespace SpectralAveraging
         {
             List<double> values = initialValues.ToList();
             int n = 0;
-            double iterationLimitforHuberLoop = 0.01;
-            double averageAbsoluteDeviation = Math.Sqrt(2 / Math.PI) * (sValueMax + sValueMin) / 2;
+            double iterationLimitforHuberLoop = 0.0005;
             double medianLeftBound;
             double medianRightBound;
             double windsorizedStandardDeviation;
+            int breakpoint = 0;
             do
             {
                 if (!values.Any())
@@ -133,14 +133,13 @@ namespace SpectralAveraging
                 double[] toProcess = values.ToArray();
                 do // calculates a new median and standard deviation based on the values to do sigma clipping with (Huber loop)
                 {
-                    medianLeftBound = median - sValueMin * standardDeviation;
-                    medianRightBound = median + sValueMax * standardDeviation;
+                    medianLeftBound = median - 1.5 * standardDeviation;
+                    medianRightBound = median + 1.5 * standardDeviation;
                     toProcess.Winsorize(medianLeftBound, medianRightBound);
                     median = BasicStatistics.CalculateMedian(toProcess);
                     windsorizedStandardDeviation = standardDeviation;
-                    // TODO: Annotate magic value.
-                    // Technically, the magic value is some derivation from a normal distribution
-                    standardDeviation = BasicStatistics.CalculateStandardDeviation(toProcess) * 1.05;
+                    standardDeviation = BasicStatistics.CalculateStandardDeviation(toProcess) * 1.134;
+                    var temp = Math.Abs(standardDeviation - windsorizedStandardDeviation) / windsorizedStandardDeviation;
                 } while (Math.Abs(standardDeviation - windsorizedStandardDeviation) / windsorizedStandardDeviation > iterationLimitforHuberLoop);
 
                 n = 0;

--- a/SpectralAveraging/Averaging/OutlierRejection.cs
+++ b/SpectralAveraging/Averaging/OutlierRejection.cs
@@ -119,7 +119,7 @@ namespace SpectralAveraging
         {
             List<double> values = initialValues.ToList();
             int n = 0;
-            double iterationLimitforHuberLoop = 0.0005;
+            double iterationLimitforHuberLoop = 0.00005;
             double medianLeftBound;
             double medianRightBound;
             double windsorizedStandardDeviation;
@@ -139,7 +139,6 @@ namespace SpectralAveraging
                     median = BasicStatistics.CalculateMedian(toProcess);
                     windsorizedStandardDeviation = standardDeviation;
                     standardDeviation = BasicStatistics.CalculateStandardDeviation(toProcess) * 1.134;
-                    var temp = Math.Abs(standardDeviation - windsorizedStandardDeviation) / windsorizedStandardDeviation;
                 } while (Math.Abs(standardDeviation - windsorizedStandardDeviation) / windsorizedStandardDeviation > iterationLimitforHuberLoop);
 
                 n = 0;
@@ -153,7 +152,7 @@ namespace SpectralAveraging
                         i--;
                     }
                 }
-            } while (n > 0);
+            } while (n > 0 && values.Count > 1); // break loop if nothing was rejected, or only one value remains
             return values.ToArray();
         }
 
@@ -252,11 +251,17 @@ namespace SpectralAveraging
             {
                 if (initialValues[i] < medianLeftBound)
                 {
-                    initialValues[i] = medianLeftBound;
+                    if (i < initialValues.Length && initialValues.Any(p => p > medianLeftBound))
+                        initialValues[i] = initialValues.First(p => p > medianLeftBound);
+                    else
+                        initialValues[i] = medianLeftBound;
                 }
                 else if (initialValues[i] > medianRightBound)
                 {
-                    initialValues[i] = medianRightBound;
+                    if (i != 0 && initialValues.Any(p => p < medianRightBound))
+                        initialValues[i] = initialValues.Last(p => p < medianRightBound);
+                    else
+                        initialValues[i] = medianRightBound;
                 }
             }
         }

--- a/SpectralAveraging/Averaging/SpectralMerging.cs
+++ b/SpectralAveraging/Averaging/SpectralMerging.cs
@@ -94,7 +94,7 @@ namespace SpectralAveraging
             {
                 // linq is probably slow 
                 xArray[i] = xValuesBin[i].Where(p => p != 0).Average();
-                yArray[i] = ProcessSingleMzArray(yValuesBin[i], options);
+                yArray[i] = ProcessSingleMzArray(yValuesBin[i].OrderBy(p => p).ToArray(), options);
             }
 
             // Create new MsDataScan to return

--- a/Tests/TestOutlierRejection.cs
+++ b/Tests/TestOutlierRejection.cs
@@ -68,19 +68,20 @@ namespace Tests
         {
             #region Windsorized Sigma Clipping
 
-            var test = new double[] { 100, 80, 60, 50, 40, 30, 20, 10, 0 };
+            var test = new double[] { 0, 10, 20, 30, 40 ,50, 60, 70, 80, 90, 100  };
             double[] windsorizedSigmaClipped = OutlierRejection.WinsorizedSigmaClipping(test, 1.5, 1.5);
-            var expected = new double[] { 60, 50, 40, 30, 20, 10 };
+            var expected = new double[] { 30, 40, 50, 60, 70 };
             Assert.That(windsorizedSigmaClipped, Is.EqualTo(expected));
 
             test = new double[] { 100, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 30, 15 };
-            expected = new double[] { 63d, 62d, 61d, 60d, 59d, 58d };
+            test = new double[] { 15, 30, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 100 };
+            expected = new double[] { 58d, 59d, 60d, 61d, 62d, 63d };
             windsorizedSigmaClipped = OutlierRejection.WinsorizedSigmaClipping(test, 1.5, 1.5);
             Assert.That(windsorizedSigmaClipped, Is.EqualTo(expected));
 
             windsorizedSigmaClipped = OutlierRejection.WinsorizedSigmaClipping(test, 1.3, 1.3);
-            expected = new double[] { 64d, 63d, 62d, 61d, 60d, 59d, 58d, 57, 56 };
-            Assert.That(windsorizedSigmaClipped, Is.EqualTo(expected));
+			expected = new double[] { 58d, 59d, 60d, 61d, 62d };
+			Assert.That(windsorizedSigmaClipped, Is.EqualTo(expected));
 
             #endregion
 		}


### PR DESCRIPTION
Fixed the magic number in Winsorized sigma clipping. Made it so that the median bounds are calculated form 1.5 standard deviations away, exactly like PixInsight. Must have misinterpreted their documentation when initially creating the function. 

Changed winsorize function to replace the value with the next closest value, instead of the median, as PixInsight described. Their text representation of the function showed it being replaced with the median, which is why it was initially coded that way, but it does not match their example. Now the median will be used only if the nearest value does not exist